### PR TITLE
add the g and l options for the mOTU profiler.

### DIFF
--- a/motus.ngm/2.1/module.yaml
+++ b/motus.ngm/2.1/module.yaml
@@ -5,7 +5,7 @@ functions:
         nglName: motus
         arg0: ./run.sh
 
-        arg1: 
+        arg1:
             atype: readset
             can_gzip: true
         additional:
@@ -33,6 +33,14 @@ functions:
                     - family
                     - genus
                     - mOTU
+            -
+                name: no_marker_genes
+                atype: int
+                def: 3
+            -
+                name: length_alignment
+                atype: int
+                def: 75
         return:
             rtype: counts
             name: ofile
@@ -48,4 +56,3 @@ citation: >
     & Shinichi Sunagawa. Microbial abundance, activity and population genomic
     profiling with mOTUs2; Nature Communications 10, Article number: 1014
     (2019). doi: 10.1038/s41467-019-08844-4
-

--- a/motus.ngm/2.1/run.sh
+++ b/motus.ngm/2.1/run.sh
@@ -41,7 +41,7 @@ if [[ -z "$1" ]] ; then
     fi
 else
     # Parsing arguments passed
-    ARG_PARSE="getopt -o s:Io:t:a -l sample:,speci_only,ofile:,taxonomic_level:,rel_abund -n $0 --"
+    ARG_PARSE="getopt -o s:Io:t:g:y:a -l sample:,speci_only,ofile:,taxonomic_level:,no_marker_genes:,length_alignment:,rel_abund -n $0 --"
 
     # We process arguments twice to handle any argument parsing error:
     ARG_ERROR=$($ARG_PARSE "$@" 2>&1 1>/dev/null)
@@ -70,6 +70,8 @@ else
     # to -c (counts) and unset RELABUND if user asked for --rel_abund
     RELABUND="-c"
     TAXLEVEL=""
+    NOMG="3"
+    LENALGN="75"
 
     while true; do
         case "$1" in
@@ -96,6 +98,16 @@ else
             -t|--taxonomic_level)
                 shift
                 TAXLEVEL="$1"
+                shift
+                ;;
+            -g|--no_marker_genes)
+                shift
+                NOMG="$1"
+                shift
+                ;;
+            -y|--length_alignment)
+                shift
+                LENALGN="$1"
                 shift
                 ;;
             --)
@@ -138,6 +150,8 @@ else
         $RELABUND \
         -t "$NGLESS_NR_CORES" \
         -k "${TAXLEVEL}" \
+        -g "${NOMG}" \
+        -l "${LENALGN}" \
         -n "${SAMPLE}" \
         -o "${TMPBINDIR}/output.txt" \
         ${READS}

--- a/motus.ngm/README.md
+++ b/motus.ngm/README.md
@@ -1,6 +1,6 @@
 # About
 
-This external module integrates: 
+This external module integrates:
 
 mOTUs version 2.1
 
@@ -29,6 +29,8 @@ Arguments for `motus`:
 | `specI_only` | flag | false | false |   |
 | `relative_abundance` | flag | false | false |   |
 | `taxonomic_level` | option | false | `mOTU` | `kingdom`, `phylum`, `class`, `order`, `family`, `genus`, `mOTU` |
+| `no_marker_genes` | option | false | `3` | `1..10` |
+| `length_alignment` | option | false | `75` |  |
 
 Returns `counts` compatible with `collect()`.
 


### PR DESCRIPTION
Allow more control over the mOTUsv2 profiler within `ngless`:
- add option `g` (number of marker genes cutoff), implemented as `no_marker_genes` within the `motus` call in `ngless`
- add option `l` (minimum length for the alignment), implemented as `length_alignment` within the `motus` call in `ngless`